### PR TITLE
removed docker installation from Dockerfile

### DIFF
--- a/model-regist/docker/Dockerfile
+++ b/model-regist/docker/Dockerfile
@@ -12,14 +12,8 @@ RUN apt-get install -y \
     gnupg \
     lsb-release
 
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
-RUN echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-
-RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN apt-get update
 
 RUN apt-get install -y python3-pip\
     python3


### PR DESCRIPTION
I believe that the model registry will not be launching docker containers, so I suggest removing the installation of docker in the Dockerfile. With this change, the model registry can operate in both amd64 and arm64.